### PR TITLE
Update timout for redirect to 5 seconds, not 90

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,11 @@
 # Description
-<!-- Please include a summary of the change and which issue is fixed -->
+<!-- Please include a summary of the issue and the change and which issue is fixed -->
 
 ## Changes
 <!-- Please describe the proposed changes -->
-- example change here
+- for example
 
-## Related Issue
-<!-- If applicable, please link to the issue this PR addresses -->
+## Gif
 
-## Additional Information
-<!-- Any additional information that is important to this PR such as screenshots of how the component looks before and after the change -->
-
-## Add a funny Gif
-
-<!-- Add a compulsory gif to your PR-->
+<!-- Add a gif to your PR-->
 ![funnygif](funny_gif_link_here)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -33,7 +33,7 @@
 import { ref, onMounted } from 'vue'
 
 const redirectUrl = 'https://westernwilson.webflow.io/'
-const redirectDelay = 90000 // 9 seconds
+const redirectDelay = 5000 // 5 seconds
 const progress = ref(0)
 
 onMounted(() => {


### PR DESCRIPTION
## Changes
<!-- Please describe the proposed changes -->
- change redirect seconds to 5 instead of the long 90 secs
- update pr template

## Add a Gif

<!-- Add a compulsory gif to your PR-->
![funnygif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXRsdDBlajgxdmJyejk3M2o2eWhxanVnN2J1d3Y3Y2F4OWpvbTB1ZSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/CZGcUfnAy3ayJw2eZX/giphy.gif)
