### PR TITLE
Add dev container setup with firewall configuration and Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(su *)"
+    ]
+  }
+}

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,32 @@
+# Dev Container Quick Start
+
+Requires Docker (or Docker Desktop) and the VS Code "Dev Containers" extension.
+
+1. Open this repo in VS Code, then run **Dev Containers: Reopen in Container** from the command palette (`Cmd/Ctrl+Shift+P`).
+2. Once it's built, log in to GitHub and Claude:
+
+```zsh
+gh auth login
+
+claude auth login
+```
+
+GitHub credentials live in the container and are wiped on rebuild. Claude credentials are kept in a mounted volume (`claude-code-config-${devcontainerId}`), so you only need to log in once per project.
+
+For the full walkthrough —including why the orange "use your subscription" button hangs in a container, and the `~/.claude` ownership gotcha if you skip the `postCreateCommand` chown— see [westernwilson.com/reflections/containerising-my-coding-agent](https://westernwilson.com/reflections/containerising-my-coding-agent/).
+
+## Forking this setup
+
+Copying `.devcontainer/` into your own repo? Update the hardcoded git identity (`user.name`/`user.email`) in `post-create.sh`.
+
+## Network
+
+`init-firewall.sh` restricts outbound traffic to an allow-list (GitHub, npm, Anthropic, VS Code, Sentry). Add a domain there if a tool you install needs network access — then **Rebuild Container** to pick up the change (see Sudo section below for why a plain restart isn't enough).
+
+## Sudo
+
+The `vscode` user only gets passwordless `sudo` to run one exact command: `/usr/local/sbin/init-firewall.sh`. That's a root-owned copy of `init-firewall.sh`, frozen there once by `post-create.sh` while the `common-utils` feature's broad default sudo grant is still active (the only point in the container's lifecycle where that's safe). `vscode` can't edit it because it lives outside the bind-mounted workspace. It also can't run raw `iptables`/`ipset`/anything else as root. Everything else, including `sudo iptables -F` directly, needs a password (which doesn't exist for vscode user).
+
+This configuration stops an agent running with `--dangerously-skip-permissions` from disabling the firewall. It can only ever re-run the frozen, known-good script, never tamper with it or escalate further.
+
+`.claude/settings.json` adds a second layer of protection on top, denying `sudo`/`su` at the Claude Code permission level; that layer doesn't apply under `--dangerously-skip-permissions`, which is why the sudoers restriction matters more.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,8 @@
 {
-  // devcontainer.json supports comments (JSONC) — VS Code / Dev Containers read them fine.
   "name": "agent-codey",
-
-  // Microsoft's maintained Ubuntu base. Ships a non-root `vscode` user,
-  // which we run as below (required if you ever use --dangerously-skip-permissions).
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 
   "features": {
-    // zsh + oh-my-zsh, set as the default shell. Also wires up the vscode user.
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installZsh": true,
       "configureZshAsDefaultShell": true,
@@ -28,27 +23,27 @@
     "ghcr.io/devcontainers/features/terraform:1": {},
     "ghcr.io/devcontainers/features/hugo:1": {},
 
-    // kubectl (+ helm). minikube off — flip to "latest" if you want a local cluster.
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "minikube": "none"
     },
 
-    // Claude Code as the feature, so it auto-updates inside the container.
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
   },
 
-  // Non-root user. Keep this set.
   "remoteUser": "vscode",
 
-  // Persist Claude Code auth, settings, and session history across rebuilds so you
-  // don't re-login every time. ${devcontainerId} keeps it isolated per project.
   "mounts": [
     "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume"
   ],
 
+  "remoteEnv": {
+    "DISABLE_TELEMETRY": "1"
+  },
+
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
-  "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.claude && zsh .devcontainer/post-create.sh",
-  "postStartCommand": "sudo zsh .devcontainer/init-firewall.sh",
+  "postCreateCommand": "sudo zsh .devcontainer/post-create.sh",
+  "postStartCommand": "sudo /usr/local/sbin/init-firewall.sh",
+  "waitFor": "postStartCommand",
 
   "customizations": {
     "vscode": {
@@ -62,7 +57,10 @@
         "github.vscode-github-actions",
         "amazonwebservices.aws-toolkit-vscode",
         "golang.go"
-      ]
+      ],
+      "settings": {
+        "telemetry.telemetryLevel": "off"
+      }
     }
   }
 }

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,6 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 echo "Setting up firewall rules to restrict outbound traffic to only allowed domains..."
 # 1. Extract Docker DNS info BEFORE any flushing
-DOCKER_DNS_RULES=$(sudo iptables-save -t nat | grep "127\.0\.0\.11" || true)
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
 
 # Flush existing rules and delete existing ipsets
 iptables -F
@@ -59,7 +62,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add allowed-domains "$cidr" -exist
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
@@ -84,9 +87,10 @@ for domain in \
         if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             echo "ERROR: Invalid IP from DNS for $domain: $ip"
             exit 1
+            
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add allowed-domains "$ip" -exist
     done < <(echo "$ips")
 done
 
@@ -101,23 +105,23 @@ HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
 echo "Host network detected as: $HOST_NETWORK"
 
 # Set up remaining iptables rules
-sudo iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
-sudo iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
 
 # Set default policies to DROP first
-sudo iptables -P INPUT DROP
-sudo iptables -P FORWARD DROP
-sudo iptables -P OUTPUT DROP
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
 
 # First allow established connections for already approved traffic
-sudo iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-sudo iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
 # Then allow only specific outbound traffic to allowed domains
-sudo iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 
 # Explicitly REJECT all other outbound traffic for immediate feedback
-sudo iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
 echo "Firewall configuration complete"
 echo "Verifying firewall rules..."

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Enabling corepack and preparing pnpm..."
-corepack enable
-corepack prepare pnpm@latest --activate
+echo "Setting up Claude Code auth, settings, and session history persistence..."
+sudo chown -R vscode:vscode /home/vscode/.claude
 
 echo "Setting up git aliases..."
 git config --global user.name "wjkw1"
@@ -34,3 +33,14 @@ alias t=terraform
 source <(kubectl completion zsh)
 compdef k=kubectl
 EOF
+
+echo "Freezing init-firewall.sh outside the workspace mount..."
+sudo install -o root -g root -m 0755 \
+    "${PWD}/.devcontainer/init-firewall.sh" /usr/local/sbin/init-firewall.sh
+
+echo "Restricting passwordless sudo to the frozen firewall script only..."
+sudo tee /etc/sudoers.d/vscode > /dev/null <<'EOF'
+vscode ALL=(root) NOPASSWD: /usr/local/sbin/init-firewall.sh
+EOF
+sudo chmod 0440 /etc/sudoers.d/vscode
+sudo visudo -c

--- a/content/reflections/2026-06-21-containerising-my-coding-agent.md
+++ b/content/reflections/2026-06-21-containerising-my-coding-agent.md
@@ -1,0 +1,86 @@
+---
+title: "Containerising my coding agent"
+date: 2026-06-21
+slug: "containerising-my-coding-agent"
+tags: ["ai", "devtools", "devops"]
+---
+
+I containerised Claude Code this week because I wanted to let it run with fewer guardrails and not hand it unlimited access the rest of my machine. There's a [Hacker News thread](https://news.ycombinator.com/item?id=46268222) from 6 months ago about someone running Claude in yolo mode who asked it to clean something up and watched it `rm -rf` their home directory 😅. So let's aim to at least avoid that.
+
+One way to protect against it is by containerising my dev environment to lock down Claude. Thankfully, I found [Dev Containers](https://containers.dev), which turned into its own rabbit hole but means I don't have to maintain my own docker image.
+
+This reflection post talks through the containerised setup and some issues I faced while setting it up. All of it is in this website's github repo's [.devcontainer/](https://github.com/wjkw1/westernwilson.com/tree/main/.devcontainer) directory if you want to skip ahead.
+
+## Feature or docker image?
+
+I assumed that Anthropic would ship an official Claude base image you build on top of. They don't, they only post a recommended starting point. Claude Code installs into any [Dev Container](https://code.claude.com/docs/en/devcontainer) through the `ghcr.io/anthropics/devcontainer-features/claude-code:1.0` feature, which you reference in `devcontainer.json` like [any other devcontainers feature](https://containers.dev/features). It works wherever the Dev Containers spec is supported e.g. VS Code, Codespaces, JetBrains, and (with some rough edges) Cursor. In VS Code it can be configured to pull in the Claude Code extension, keeping Claude decoupled from the base image entirely.
+
+That leaves three layers to assemble: a base image, the tooling you use, and Claude Code on top. The real decision is whether you bake those middle two layers into a custom docker image you push to a registry, or assemble them per-repo through `devcontainer.json` features. A custom image is the better call for a team, where you want a validated, secure, and reusable environment everyone builds on. For a solo setup spun up per-repo, features are easier. The cost is a slow first build and less control over exactly what lands in the image, which is what `post-create.sh` helps automate somewhat.
+
+My `devcontainer.json` ended up looking like this, trimmed to the main parts:
+
+```jsonc
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+  },
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume"
+  ],
+  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+  "postCreateCommand": "sudo zsh .devcontainer/post-create.sh",
+  "postStartCommand": "sudo /usr/local/sbin/init-firewall.sh",
+  "waitFor": "postStartCommand"
+}
+```
+
+The non-root `vscode` user is important if you ever run with `--dangerously-skip-permissions`, Claude Code requires it. The named volume on `~/.claude` means login persists across rebuilds instead of re-authenticating every time. The `NET_ADMIN`/`NET_RAW` capabilities exist so that we can create the containerised firewall. `waitFor: postStartCommand` blocks the terminal until that firewall script finishes, so there's no window where Claude is already running before egress is locked down.
+
+`post-create.sh` is the everyday stuff a feature-based setup doesn't hand you for free: setting git aliases, adding a couple of zsh aliases for `kubectl` and `terraform`, locking down `sudo`/`su`.
+
+`init-firewall.sh` sets default-DROP policies on iptables, then builds an `ipset` allowlist of everything the container is allowed to reach outbound. Part of that allowlist is GitHub's own published IP ranges, fetched live at container start:
+
+```zsh
+gh_ranges=$(curl -s https://api.github.com/meta)
+while read -r cidr; do
+    ipset add allowed-domains "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+```
+
+Everything else —npm, `api.anthropic.com`, the VS Code marketplace— gets resolved and added individually. The firewall script finishes by checking its own work: it tries `curl https://example.com` and expects that to fail, then tries `curl https://api.github.com/zen` and expects that to succeed.
+
+## Firewall and sudo
+
+I spent a decent chunk of time configuring who's allowed to touch `iptables`. The `common-utils` feature grants the `vscode` user blanket passwordless `sudo` by default, and my first cut of `post-create.sh` narrowed that down to the `iptables`/`iptables-save`/`ipset` binaries themselves, with no argument restriction. Which meant Claude or anything else running as `vscode`, including under `--dangerously-skip-permissions`, could just run `sudo iptables -F && sudo iptables -P OUTPUT ACCEPT` and the firewall would be gone! Anthropic's own reference devcontainer avoids this by granting `sudo` on one fixed script path instead of the raw binaries, baked into their image at build time so the script itself can't be edited either. I didn't want a custom Dockerfile yet, but dev containers can do the same thing with just `postCreateCommand`: copy `init-firewall.sh` to a root-owned `/usr/local/sbin/init-firewall.sh` outside the bind-mounted workspace while the feature's broad sudo grant is still active, then narrow `sudo` down to NOPASSWD on that one frozen executable file only. The tradeoff is that editing the live `init-firewall.sh` to allow a new domain now needs a full **Rebuild Container**, not just a restart, since the frozen copy is what actually runs.
+
+Claude has it's own way to limit it's own execution too using `.claude/settings.json`. We've configured this on top to deny any `Bash(sudo *)` and `Bash(su *)` commands, so in normal mode Claude won't even attempt the command. But `--dangerously-skip-permissions` does exactly what its name says: it bypasses every permission rule, deny rules included. So that file is a speed bump for the default mode, not something to lean on once the safety's off. The frozen-script sudoers restriction is the one that locks it down regardless, because it's enforced by the OS, not by Claude Code.
+
+## Gap in the firewall
+
+One thing I noticed was that `api.github.com/meta`'s ip ranges aren't scoped to the API. They cover GitHub's whole edge network, which includes GitHub Pages in some cases. For example, this website, [westernwilson.com](https://westernwilson.com), runs on GitHub Pages. So with the firewall up and supposedly restricting the agent to an approved set of domains, I could still reach my own site. And by the same logic, any other `*.github.io` page, or anything hosted there by someone with worse intentions. A page on `*.github.io` could potentially hold a payload hosted somewhere else entirely, and the firewall would wave it through without ever knowing the difference.
+
+I see three ways to close that off:
+
+- Proxy the traffic and filter on hostname instead of IP. Cleanest in theory, but Encrypted Client Hello can still hide the hostname from anything sitting.
+- Drop `*.github.io` from the allowlist entirely. Unfortunately this also takes `raw.githubusercontent.com` out too since they share the same ip ranges, but if that's not something the container needs, it's a fine trade.
+- Accept the risk and move on.
+
+I haven't picked one yet, for now I'm sitting with the risk while I think about which tradeoff is actually worth it.
+
+## Logging in to Claude
+
+Logging in had its own gotcha. In VS Code there is a big orange "use your subscription" button that opens a browser and waits for a callback to `localhost`, which never makes it back into the container and just hangs. The fix is to skip the button, open a terminal inside the container and run `claude`, which kicks off the same browser flow but resolves the callback correctly. 
+
+We then use `~/.claude`, which is now owned by the `vscode` thanks to the `chown` at the top of `post-create.sh`, so once logged in, we gain stickier login sessions.
+
+In doing the whole login dance from a bare terminal meant that my first real session with Claude Code inside the dev container was just text based interaction with no IDE extension wrapper around it at all. It's an interesting way to work and removes a lot of the UI distraction, but not something I'll rely on fulltime.
+
+## Port forwarding
+
+The other thing that briefly worried me is VS Code forwarded around thirty-two ports the moment the container came up. My first thought was that something in the container was reaching out on its own. It's not, after some searching I found that it's VS Code's automatic port-forwarding scanning the container for anything listening on a port, for example a dev server that you'll want to open in a browser. It's a separate, fairly trigger-happy feature, and apparently a known source of noise; [This GitHub issue](https://github.com/microsoft/vscode-remote-release/issues/10926) describes the exact same "over 20 ports auto-forwarded" behaviour after a setting silently flips from `process` to `hybrid` detection mode.
+
+If you want to see the actual config rather than the excerpts above, it's all in this repo under [.devcontainer/](https://github.com/wjkw1/westernwilson.com/tree/main/.devcontainer). Treat it as a personal setup to extend, not a hardened image to copy verbatim. 
+
+Further reading: Anthropic's [Dev Containers docs](https://code.claude.com/docs/en/devcontainer) and the [VS Code Dev Containers tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial).


### PR DESCRIPTION
    - Introduced a new settings.json file to restrict Bash sudo and su commands for Claude Code.
    - Created README.md for dev container quick start instructions, including GitHub and Claude authentication steps.
    - Updated devcontainer.json to include remote environment variables and refined post-create and post-start commands.
    - Enhanced init-firewall.sh to improve firewall rules and added checks for allowed domains.
    - Modified post-create.sh to set up Claude Code authentication and restrict sudo permissions to a specific script.
    - Added a new reflection document on containerizing Claude Code for better security and usability.
