### PR TITLE
Add Hugo mention to footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,5 +12,6 @@
     </ul>
     {{ end }}
     <p class="text-sm text-muted m-0">© {{ now.Year }} {{ .Site.Params.author }}</p>
+    <p class="text-xs text-muted m-0">Built with <a href="https://gohugo.io/" rel="noopener" class="text-muted! hover:text-accent!">Hugo</a></p>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Adds a small "Built with Hugo" line below the copyright text in the footer, linking to gohugo.io, as an honourable mention to the framework used to build the site.

## Test plan
- [x] Built the site with `hugo` and confirmed the new line renders correctly in `public/index.html`
- [x] Visually confirmed via dev server that the line appears below the copyright text with consistent muted styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)